### PR TITLE
[WIP] Fix localization

### DIFF
--- a/CharacterStatsClassicUI.lua
+++ b/CharacterStatsClassicUI.lua
@@ -17,11 +17,11 @@ local UIConfig = core.UIConfig;
 local CSC_UIFrame = core.UIConfig;
 
 local statsDropdownList = {
-    "Base Stats",
-    "Melee",
-    "Ranged",
-    "Spell",
-    "Defenses"
+    PLAYERSTAT_BASE_STATS,
+    PLAYERSTAT_MELEE_COMBAT,
+    PLAYERSTAT_RANGED_COMBAT,
+    PLAYERSTAT_SPELL_COMBAT,
+    PLAYERSTAT_DEFENSES
 }
 
 local NUM_STATS_TO_SHOW = 6;
@@ -68,10 +68,10 @@ function UIConfig:SetCharacterStats(statsTable, category)
     --print(characterFrameTab);
     CSC_ResetStatFrames(statsTable);
 
-    if category == "Base Stats" then
+    if category == PLAYERSTAT_BASE_STATS then
         -- str, agility, stamina, intelect, spirit, armor
         CSC_PaperDollFrame_SetPrimaryStats(statsTable, "player");
-    elseif category == "Defenses" then
+    elseif category == PLAYERSTAT_DEFENSES then
         -- armor, defense, dodge, parry, block
         CSC_PaperDollFrame_SetArmor(statsTable[1], "player");
         CSC_PaperDollFrame_SetDefense(statsTable[2], "player");
@@ -79,7 +79,7 @@ function UIConfig:SetCharacterStats(statsTable, category)
         CSC_PaperDollFrame_SetParry(statsTable[4], "player");
         CSC_PaperDollFrame_SetBlock(statsTable[5], "player");
         --CSC_PaperDollFrame_SetStagger(statsTable[6], "player"); Is this useful?
-    elseif category == "Melee" then
+    elseif category == PLAYERSTAT_MELEE_COMBAT then
         -- damage, Att Power, speed, hit raiting, crit chance
         CSC_PaperDollFrame_SetDamage(statsTable[1], "player", category);
         CSC_PaperDollFrame_SetMeleeAttackPower(statsTable[2], "player");
@@ -87,13 +87,13 @@ function UIConfig:SetCharacterStats(statsTable, category)
         CSC_PaperDollFrame_SetCritChance(statsTable[4], "player", category);
         CSC_PaperDollFrame_SetHitChance(statsTable[5], "player");
         --CSC_PaperDollFrame_SetHitChance(statsTable[6], "player");--test
-    elseif category == "Ranged" then
+    elseif category == PLAYERSTAT_RANGED_COMBAT then
         CSC_PaperDollFrame_SetDamage(statsTable[1], "player", category);
         CSC_PaperDollFrame_SetRangedAttackPower(statsTable[2], "player");
         CSC_PaperDollFrame_SetRangedAttackSpeed(statsTable[3], "player");
         CSC_PaperDollFrame_SetCritChance(statsTable[4], "player", category);
         CSC_PaperDollFrame_SetHitChance(statsTable[5], "player");
-    elseif category == "Spell" then
+    elseif category == PLAYERSTAT_SPELL_COMBAT then
         -- bonus dmg, bonus healing, crit chance, mana regen
         CSC_PaperDollFrame_SetSpellPower(statsTable[1], "player");
         CSC_PaperDollFrame_SetHealing(statsTable[2], "player");

--- a/CharacterStatsClassicUtils.lua
+++ b/CharacterStatsClassicUtils.lua
@@ -510,25 +510,16 @@ function CSC_PaperDollFrame_SetSpellPower(statFrame, unit)
     end)
 
 	local MAX_SPELL_SCHOOLS = 7;
-	local minModifier = 0;
-
 	local holySchool = 2;
+
 	-- Start at 2 to skip physical damage
-	minModifier = GetSpellBonusDamage(holySchool);
-
-	if (statFrame.bonusDamage) then
-		table.wipe(statFrame.bonusDamage);
-	else
-		statFrame.bonusDamage = {};
-	end
-	statFrame.bonusDamage[holySchool] = minModifier;
-	for i=(holySchool+1), MAX_SPELL_SCHOOLS do
+	local maxSpellDmg = GetSpellBonusDamage(holySchool);
+	for i=holySchool, MAX_SPELL_SCHOOLS do
 		local bonusDamage = GetSpellBonusDamage(i);
-		minModifier = min(minModifier, bonusDamage);
-		statFrame.bonusDamage[i] = bonusDamage;
+		maxSpellDmg = max(maxSpellDmg, bonusDamage);
 	end
 
-	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_SPELLPOWER, BreakUpLargeNumbers(minModifier), false, minModifier);
+	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_SPELLPOWER, BreakUpLargeNumbers(maxSpellDmg), false, maxSpellDmg);
 	statFrame.holyDmg = GetSpellBonusDamage(2);
 	statFrame.fireDmg = GetSpellBonusDamage(3);
 	statFrame.natureDmg = GetSpellBonusDamage(4);
@@ -548,6 +539,7 @@ function CSC_PaperDollFrame_SetManaRegen(statFrame, unit)
 	end
 
 	local base, combat = GetManaRegen();
+	
 	-- All mana regen stats are displayed as mana/5 sec.
 	base = floor(base * 5.0);
 	combat = floor(combat * 5.0);
@@ -593,6 +585,7 @@ function CSC_CharacterSpellDamageFrame_OnEnter(self)
 	GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
 	GameTooltip:SetText(STAT_SPELLPOWER, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
 	GameTooltip:AddDoubleLine(STAT_SPELLPOWER_TOOLTIP);
+	GameTooltip:AddLine("Displays the highest type of spell damage");
 	GameTooltip:AddLine(" "); -- Blank line.
 	GameTooltip:AddDoubleLine(SPELL_SCHOOL1_CAP.." "..DAMAGE..": ", format("%.2F", self.holyDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
 	GameTooltip:AddDoubleLine(SPELL_SCHOOL2_CAP.." "..DAMAGE..": ", format("%.2F", self.fireDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);

--- a/CharacterStatsClassicUtils.lua
+++ b/CharacterStatsClassicUtils.lua
@@ -421,17 +421,37 @@ function CSC_PaperDollFrame_SetArmor(statFrame, unit)
 end
 
 function CSC_PaperDollFrame_SetDefense(statFrame, unit)
-	local base, modifier = UnitDefense(unit);
+
+	local numSkills = GetNumSkillLines();
+	local skillIndex = 0;
+
+	for i = 1, numSkills do
+		local skillName = select(1, GetSkillLineInfo(i));
+
+		if (skillName == "Defense") then
+			skillIndex = i;
+			break;
+		end
+	end
+
+	local skillRank, skillModifier;
+	if (skillIndex > 0) then
+		skillRank = select(4, GetSkillLineInfo(skillIndex));
+		skillModifier = select(6, GetSkillLineInfo(skillIndex));
+	else
+		-- Temporal workaround if the "Defense" label above is localization dependent
+		skillRank, skillModifier = UnitDefense(unit); --Not working properly
+	end
 
 	local posBuff = 0;
 	local negBuff = 0;
-	if ( modifier > 0 ) then
-		posBuff = modifier;
-	elseif ( modifier < 0 ) then
-		negBuff = modifier;
+	if ( skillModifier > 0 ) then
+		posBuff = skillModifier;
+	elseif ( skillModifier < 0 ) then
+		negBuff = skillModifier;
 	end
-	local valueText, tooltipText = CSC_PaperDollFormatStat(DEFENSE_COLON, base, posBuff, negBuff);
-	local valueNum = max(0, base + posBuff + negBuff);
+	local valueText, tooltipText = CSC_PaperDollFormatStat(DEFENSE_COLON, skillRank, posBuff, negBuff);
+	local valueNum = max(0, skillRank + posBuff + negBuff);
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, DEFENSE, valueText, false, valueNum);
 	statFrame.tooltip = tooltipText;
 	tooltipText = format(DEFAULT_STATDEFENSE_TOOLTIP, valueNum, 0, valueNum*0.04, valueNum*0.04);

--- a/CharacterStatsClassicUtils.lua
+++ b/CharacterStatsClassicUtils.lua
@@ -15,9 +15,9 @@ local function CSC_GetAppropriateDamage(unit, category)
 		return UnitDamage(unit);
     end
 	]]
-	if category == "Melee" then
+	if category == PLAYERSTAT_MELEE_COMBAT then
 		return UnitDamage(unit);
-	elseif category == "Ranged" then
+	elseif category == PLAYERSTAT_RANGED_COMBAT then
 		local attackTime, minDamage, maxDamage, bonusPos, bonusNeg, percent = UnitRangedDamage(unit);
 		return minDamage, maxDamage, nil, nil, 0, 0, percent;
 	end

--- a/CharacterStatsClassicUtils.lua
+++ b/CharacterStatsClassicUtils.lua
@@ -557,7 +557,8 @@ function CSC_PaperDollFrame_SetHealing(statFrame, unit)
 	local healing = GetSpellBonusHealing();
 	local healingText = healing;
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_SPELLHEALING, healingText, false, healing);
-	statFrame.tooltip = STAT_SPELLHEALING_TOOLTIP;
+	statFrame.tooltip = STAT_SPELLHEALING.." "..healing;
+	statFrame.tooltip2 = STAT_SPELLHEALING_TOOLTIP;
 	statFrame:Show();
 end
 

--- a/CharacterStatsClassicUtils.lua
+++ b/CharacterStatsClassicUtils.lua
@@ -380,7 +380,7 @@ function CSC_PaperDollFrame_SetAttackSpeed(statFrame, unit)
 		displaySpeed =  displaySpeed;
 	end
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, speedLabel, displaySpeed, false, speed);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE..format(PAPERDOLLFRAME_TOOLTIP_FORMAT, ATTACK_SPEED).." "..displaySpeed..FONT_COLOR_CODE_CLOSE;
+	statFrame.tooltip = format(PAPERDOLLFRAME_TOOLTIP_FORMAT, ATTACK_SPEED).." "..displaySpeed;
 	statFrame:Show();
 end
 
@@ -389,7 +389,7 @@ function CSC_PaperDollFrame_SetRangedAttackSpeed(statFrame, unit)
 	local displaySpeed = format("%.2F", attackSpeed);
 
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, WEAPON_SPEED, displaySpeed, false, attackSpeed);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE..format(PAPERDOLLFRAME_TOOLTIP_FORMAT, ATTACK_SPEED).." "..displaySpeed..FONT_COLOR_CODE_CLOSE;
+	statFrame.tooltip = format(PAPERDOLLFRAME_TOOLTIP_FORMAT, ATTACK_SPEED).." "..displaySpeed;
 	statFrame:Show();
 end
 
@@ -441,7 +441,7 @@ end
 function CSC_PaperDollFrame_SetDodge(statFrame, unit)
 	local chance = GetDodgeChance();
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_DODGE, chance, true, chance);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE..format(PAPERDOLLFRAME_TOOLTIP_FORMAT, DODGE_CHANCE).." "..string.format("%.2F", chance).."%"..FONT_COLOR_CODE_CLOSE;
+	statFrame.tooltip = format(PAPERDOLLFRAME_TOOLTIP_FORMAT, DODGE_CHANCE).." "..string.format("%.2F", chance).."%";
 	--statFrame.tooltip2 = format(CR_DODGE_TOOLTIP, GetCombatRating(CR_DODGE), GetCombatRatingBonus(CR_DODGE));
 	statFrame:Show();
 end
@@ -449,7 +449,7 @@ end
 function CSC_PaperDollFrame_SetParry(statFrame, unit)
 	local chance = GetParryChance();
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_PARRY, chance, true, chance);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE..format(PAPERDOLLFRAME_TOOLTIP_FORMAT, PARRY_CHANCE).." "..string.format("%.2F", chance).."%"..FONT_COLOR_CODE_CLOSE;
+	statFrame.tooltip = format(PAPERDOLLFRAME_TOOLTIP_FORMAT, PARRY_CHANCE).." "..string.format("%.2F", chance).."%";
 	--statFrame.tooltip2 = format(CR_PARRY_TOOLTIP, GetCombatRating(CR_PARRY), GetCombatRatingBonus(CR_PARRY));
 	statFrame:Show();
 end
@@ -468,7 +468,7 @@ end
 function CSC_PaperDollFrame_SetBlock(statFrame, unit)
 	local chance = GetBlockChance();
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_BLOCK, chance, true, chance);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE..format(PAPERDOLLFRAME_TOOLTIP_FORMAT, BLOCK_CHANCE).." "..string.format("%.2F", chance).."%"..FONT_COLOR_CODE_CLOSE;
+	statFrame.tooltip = format(PAPERDOLLFRAME_TOOLTIP_FORMAT, BLOCK_CHANCE).." "..string.format("%.2F", chance).."%";
 	
 	--[[
 	local shieldBlockArmor = GetShieldBlock();
@@ -490,7 +490,7 @@ function CSC_PaperDollFrame_SetStagger(statFrame, unit)
 	local stagger, staggerAgainstTarget = C_PaperDollInfo.GetStaggerPercentage(unit);
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_STAGGER, stagger, true, stagger);
 
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE..format(PAPERDOLLFRAME_TOOLTIP_FORMAT, STAGGER).." "..string.format("%.2F%%",stagger)..FONT_COLOR_CODE_CLOSE;
+	statFrame.tooltip = format(PAPERDOLLFRAME_TOOLTIP_FORMAT, STAGGER).." "..string.format("%.2F%%",stagger);
 	statFrame.tooltip2 = format(STAT_STAGGER_TOOLTIP, stagger);
 	if (staggerAgainstTarget) then
 		statFrame.tooltip3 = format(STAT_STAGGER_TARGET_TOOLTIP, staggerAgainstTarget);
@@ -555,7 +555,7 @@ function CSC_PaperDollFrame_SetManaRegen(statFrame, unit)
 	local combatText = BreakUpLargeNumbers(combat);
 	-- Combat mana regen is most important to the player, so we display it as the main value
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, MANA_REGEN, combatText, false, combat);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE .. format(PAPERDOLLFRAME_TOOLTIP_FORMAT, MANA_REGEN) .. " " .. combatText .. FONT_COLOR_CODE_CLOSE;
+	statFrame.tooltip = format(PAPERDOLLFRAME_TOOLTIP_FORMAT, MANA_REGEN) .. " " .. combatText;
 	-- Base (out of combat) regen is displayed only in the subtext of the tooltip
 	statFrame.tooltip2 = format(MANA_REGEN_TOOLTIP, baseText);
 	statFrame:Show();
@@ -565,7 +565,7 @@ function CSC_PaperDollFrame_SetHealing(statFrame, unit)
 	local healing = GetSpellBonusHealing();
 	local healingText = healing;
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_SPELLHEALING, healingText, false, healing);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE..STAT_SPELLHEALING_TOOLTIP..FONT_COLOR_CODE_CLOSE;
+	statFrame.tooltip = STAT_SPELLHEALING_TOOLTIP;
 	statFrame:Show();
 end
 

--- a/CharacterStatsClassicUtils.lua
+++ b/CharacterStatsClassicUtils.lua
@@ -428,7 +428,7 @@ function CSC_PaperDollFrame_SetDefense(statFrame, unit)
 	for i = 1, numSkills do
 		local skillName = select(1, GetSkillLineInfo(i));
 
-		if (skillName == "Defense") then
+		if (skillName == DEFENSE) then
 			skillIndex = i;
 			break;
 		end

--- a/CharacterStatsClassicUtils.lua
+++ b/CharacterStatsClassicUtils.lua
@@ -206,7 +206,7 @@ function CSC_PaperDollFrame_SetDamage(statFrame, unit, category)
 	statFrame.melleAttack = attackWithModifier;
 
     -- If there's an offhand speed then add the offhand info to the tooltip
-	if ( offhandSpeed and category == "Melee") then
+	if ( offhandSpeed and category == PLAYERSTAT_MELEE_COMBAT) then
 		minOffHandDamage = (minOffHandDamage / percent) - physicalBonusPos - physicalBonusNeg;
 		maxOffHandDamage = (maxOffHandDamage / percent) - physicalBonusPos - physicalBonusNeg;
 
@@ -305,16 +305,16 @@ function CSC_PaperDollFrame_SetCritChance(statFrame, unit, category)
     -- Warning: For some reason these return the same value on retail.... will have to check on Classic
     local critChance;
 
-    if category == "Melee" then
+    if category == PLAYERSTAT_MELEE_COMBAT then
         critChance = GetCritChance();
-    elseif category == "Ranged" then
+    elseif category == PLAYERSTAT_RANGED_COMBAT then
         critChance = GetRangedCritChance();
-    elseif category == "Spell" then
+    elseif category == PLAYERSTAT_SPELL_COMBAT then
         critChance = GetSpellCritChance();
     end
 
     CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_CRITICAL_STRIKE, critChance, true, critChance);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE..format(PAPERDOLLFRAME_TOOLTIP_FORMAT, STAT_CRITICAL_STRIKE).." "..format("%.2F%%", critChance)..FONT_COLOR_CODE_CLOSE;
+	statFrame.tooltip = format(PAPERDOLLFRAME_TOOLTIP_FORMAT, STAT_CRITICAL_STRIKE).." "..format("%.2F%%", critChance);
 	statFrame.tooltip2 = "";
     statFrame:Show();
 end
@@ -346,8 +346,9 @@ function CSC_PaperDollFrame_SetHitChance(statFrame, unit)
 	end
 
 	local hitChanceText = hitChance;
-	CSC_PaperDollFrame_SetLabelAndText(statFrame, "Hit", hitChanceText, true, hitChance);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE.."Chance to hit enemies at your level"..FONT_COLOR_CODE_CLOSE;
+	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_HIT_CHANCE, hitChanceText, true, hitChance);
+	statFrame.tooltip = STAT_HIT_CHANCE.." "..hitChanceText;
+	statFrame.tooltip2 = format(CR_HIT_MELEE_TOOLTIP, UnitLevel("player"), hitChance);
 	statFrame:Show();
 end
 
@@ -359,8 +360,9 @@ function CSC_PaperDollFrame_SetSpellHitChance(statFrame, unit)
 	end
 
 	local hitChanceText = hitChance;
-	CSC_PaperDollFrame_SetLabelAndText(statFrame, "Spell Hit", hitChanceText, true, hitChance);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE.."Chance to hit enemies with spells at your level"..FONT_COLOR_CODE_CLOSE;
+	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_HIT_CHANCE, hitChanceText, true, hitChance);
+	statFrame.tooltip = STAT_HIT_CHANCE.." "..hitChanceText;
+	statFrame.tooltip2 = format(CR_HIT_SPELL_TOOLTIP, UnitLevel("player"), hitChance);
 	statFrame:Show();
 end
 
@@ -374,7 +376,6 @@ function CSC_PaperDollFrame_SetAttackSpeed(statFrame, unit)
 	end
 	if ( offhandSpeed ) then
 		displaySpeed =  displaySpeed.." / ".. offhandSpeed;
-		speedLabel = "Att Speed"; -- overlap fix until I find a better way of ding this
 	else
 		displaySpeed =  displaySpeed;
 	end
@@ -431,9 +432,9 @@ function CSC_PaperDollFrame_SetDefense(statFrame, unit)
 	end
 	local valueText, tooltipText = CSC_PaperDollFormatStat(DEFENSE_COLON, base, posBuff, negBuff);
 	local valueNum = max(0, base + posBuff + negBuff);
-	CSC_PaperDollFrame_SetLabelAndText(statFrame, "Defense", valueText, false, valueNum);
+	CSC_PaperDollFrame_SetLabelAndText(statFrame, DEFENSE, valueText, false, valueNum);
 	statFrame.tooltip = tooltipText;
-	statFrame.tooltip2 = "Reduces the chance to be critically hit";
+	statFrame.tooltip2 = DEFENSE_TOOLTIP;
 	statFrame:Show();
 end
 
@@ -563,8 +564,8 @@ end
 function CSC_PaperDollFrame_SetHealing(statFrame, unit)
 	local healing = GetSpellBonusHealing();
 	local healingText = healing;
-	CSC_PaperDollFrame_SetLabelAndText(statFrame, "Healing", healingText, false, healing);
-	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE.."Bonus healing"..FONT_COLOR_CODE_CLOSE;
+	CSC_PaperDollFrame_SetLabelAndText(statFrame, STAT_SPELLHEALING, healingText, false, healing);
+	statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE..STAT_SPELLHEALING_TOOLTIP..FONT_COLOR_CODE_CLOSE;
 	statFrame:Show();
 end
 
@@ -593,24 +594,24 @@ function CSC_CharacterSpellDamageFrame_OnEnter(self)
 	GameTooltip:SetText(STAT_SPELLPOWER, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
 	GameTooltip:AddDoubleLine(STAT_SPELLPOWER_TOOLTIP);
 	GameTooltip:AddLine(" "); -- Blank line.
-	GameTooltip:AddDoubleLine("Holy Damage: ", format("%.2F", self.holyDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Fire Damage: ", format("%.2F", self.fireDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Frost Damage: ", format("%.2F", self.frostDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Arcane Damage: ", format("%.2F", self.arcaneDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Shadow Damage: ", format("%.2F", self.shadowDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Nature Damage: ", format("%.2F", self.natureDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL1_CAP.." "..DAMAGE..": ", format("%.2F", self.holyDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL2_CAP.." "..DAMAGE..": ", format("%.2F", self.fireDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL4_CAP.." "..DAMAGE..": ", format("%.2F", self.frostDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL6_CAP.." "..DAMAGE..": ", format("%.2F", self.arcaneDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL5_CAP.." "..DAMAGE..": ", format("%.2F", self.shadowDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL3_CAP.." "..DAMAGE..": ", format("%.2F", self.natureDmg), NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
 	GameTooltip:Show();
 end
 
 function CSC_CharacterSpellCritFrame_OnEnter(self)
 	GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
 	GameTooltip:SetText(STAT_CRITICAL_STRIKE, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Holy Crit: ", format("%.2F", self.holyCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Fire Crit: ", format("%.2F", self.fireCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Frost Crit: ", format("%.2F", self.frostCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Arcane Crit: ", format("%.2F", self.arcaneCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Shadow Crit: ", format("%.2F", self.shadowCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
-	GameTooltip:AddDoubleLine("Nature Crit: ", format("%.2F", self.natureCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL1_CAP.." "..CRIT_ABBR..": ", format("%.2F", self.holyCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL2_CAP.." "..CRIT_ABBR..": ", format("%.2F", self.fireCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL4_CAP.." "..CRIT_ABBR..": ", format("%.2F", self.frostCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL6_CAP.." "..CRIT_ABBR..": ", format("%.2F", self.arcaneCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL5_CAP.." "..CRIT_ABBR..": ", format("%.2F", self.shadowCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+	GameTooltip:AddDoubleLine(SPELL_SCHOOL3_CAP.." "..CRIT_ABBR..": ", format("%.2F", self.natureCrit).."%", NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
 	GameTooltip:Show();
 end
 -- OnEnter Tooltip functions END

--- a/CharacterStatsClassicUtils.lua
+++ b/CharacterStatsClassicUtils.lua
@@ -434,7 +434,10 @@ function CSC_PaperDollFrame_SetDefense(statFrame, unit)
 	local valueNum = max(0, base + posBuff + negBuff);
 	CSC_PaperDollFrame_SetLabelAndText(statFrame, DEFENSE, valueText, false, valueNum);
 	statFrame.tooltip = tooltipText;
-	statFrame.tooltip2 = DEFENSE_TOOLTIP;
+	tooltipText = format(DEFAULT_STATDEFENSE_TOOLTIP, valueNum, 0, valueNum*0.04, valueNum*0.04);
+	tooltipText = tooltipText:gsub('.-\n', '', 1);
+	tooltipText = tooltipText:gsub('%b()', '');
+	statFrame.tooltip2 = tooltipText;
 	statFrame:Show();
 end
 


### PR DESCRIPTION
APPROVAL PENDING

This PR aims to make this addon display native texts on all official supported languages.
This is done by replacing all hardcoded strings that are visible to the player with global constants.
That way blizzard will do all the localization for us.

The classic version seems to support the same global string constants as retail, which is kind of strange. Anyway there are a lot more translated text available as in vanilla.

Changes explained:
1. I removed some string formatting, because the frame itself already has some formatting rules set.
2. I replaced almost all hardcoded strings with global string constants.
3. I removed `speedLabel = "Att Speed"; -- overlap fix until I find a better way of ding this` this should be handled by #3.
4. I wasnt able to find a replacement for `GameTooltip:AddLine("Displays the highest type of spell damage");` so it is still unlocalized, but I would rather remove it.
5. I wasnt able to find a good replacement for the defense tooltip so I modified the global string to make better sense. It should work on all localizations but I am not sure about the calculated values.
 6. I modified the new defense calculation to support any language, possibly making 
`-- Temporal workaround if the "Defense" label above is localization dependent`
`skillRank, skillModifier = UnitDefense(unit); --Not working properly` obsolete.

I tested everything on the german an english locales where everything works as intended.

Please review it and let me know what you think, or what I should change.