### PR TITLE
Improve defense tooltip

### DIFF
--- a/CharacterStatsClassicCallbacks.lua
+++ b/CharacterStatsClassicCallbacks.lua
@@ -194,9 +194,9 @@ function CSC_CharacterMeleeCritFrame_OnEnter(self)
 end
 
 function CSC_CharacterDefenseFrame_OnEnter(self)
+	local defenseValue, defenseModifier, playerLevel = CSC_GetDefense("player");
 	local npcWeaponskill = playerLevel*5; -- same level as player
 	local bossWeaponskill = 315; -- level 63
-	local defenseValue, defenseModifier, playerLevel = CSC_GetDefense("player");
 
 	GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
 	GameTooltip:SetText("Defense \nIncreases chance to Dodge, Block and Parry.\nDecreases chance to be hit and critically hit.", HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);

--- a/CharacterStatsClassicCallbacks.lua
+++ b/CharacterStatsClassicCallbacks.lua
@@ -192,4 +192,19 @@ function CSC_CharacterMeleeCritFrame_OnEnter(self)
 
 	GameTooltip:Show();
 end
+
+function CSC_CharacterDefenseFrame_OnEnter(self)
+	local npcWeaponskill = playerLevel*5; -- same level as player
+	local bossWeaponskill = 315; -- level 63
+	local defenseValue, defenseModifier, playerLevel = CSC_GetDefense("player");
+
+	GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
+	GameTooltip:SetText("Defense \nIncreases chance to Dodge, Block and Parry.\nDecreases chance to be hit and critically hit.", HIGHLIGHT_FONT_COLOR.r, HIGHLIGHT_FONT_COLOR.g, HIGHLIGHT_FONT_COLOR.b);
+
+	GameTooltip:AddLine(CSC_SYMBOL_SPACE); -- Blank line.
+	GameTooltip:AddLine("Effect vs.");
+	GameTooltip:AddLine(format(CSC_SYMBOL_TAB.."Level "..playerLevel.." NPC: %.2F%%", math.max(0, defenseValue+defenseModifier-npcWeaponskill)*0.04));
+	GameTooltip:AddLine(format(CSC_SYMBOL_TAB.."Level 63 NPC/Boss: %.2F%%", math.max(0, defenseValue+defenseModifier-bossWeaponskill)*0.04));
+	GameTooltip:Show();
+end
 -- OnEnter Tooltip functions END


### PR DESCRIPTION
Rewrite of the defense tooltip to show more informative data.
Values are now shown for NPCs on the same level as the player and level 63.

Strings in this PR are not localized, instead they are just plain english.

![Screenshot_20201228_201622](https://user-images.githubusercontent.com/30129213/103239675-9c179500-494e-11eb-9c2e-caa38a94fb8a.png)
![Screenshot_20201228_205645](https://user-images.githubusercontent.com/30129213/103239982-5b6c4b80-494f-11eb-9c7a-4648d10a4ede.png)

closes #48