### PR TITLE
Correctly sort addon in addon list

### DIFF
--- a/CharacterStatsClassic.toc
+++ b/CharacterStatsClassic.toc
@@ -1,7 +1,7 @@
 ## Interface: 11306
 ## Author: Peter Getov
 ## Version: 3.7.2
-## Title: |cff00aeffCharacterStatsClassic|r
+## Title: CharacterStatsClassic
 ## Notes: Advanced Character Stats
 ## DefaultState:  enabled
 ## SavedVariables: CharacterStatsClassicDB


### PR DESCRIPTION
Removing the color will make it sort correctly in the addon list inside WoW