### PR TITLE
Use GetBlockValue() instead of manually parsing item text strings

### DIFF
--- a/CharacterStatsClassicUI.lua
+++ b/CharacterStatsClassicUI.lua
@@ -5,7 +5,7 @@ core.UIConfig = {};
 
 -- Defaults
 UISettingsGlobal = {
-    useBlizzardBlockValue = false;
+    useBlizzardBlockValue = true;
     useTransparentStatsBackground = true;
     statsPanelHidden = false;
 }


### PR DESCRIPTION
Seems like blizzard correctly reports block value, including all set bonuses. The current implementation is incorrect due to the change in SoD's T1 warrior set. Battlegear of Might has been changed to Immoveable Might meaning set bonuses are not calculated properly.

I gave an attempt at fixing the string parsing to try and match the correct behavior, but decided against it in favor of just calling the API.

ExtendedCharacterStats does something similar: https://github.com/BreakBB/ExtendedCharacterStats/blob/d2e6bc84ff184d577c518c32e258fc70fd7bfcf8/Modules/Data/Defense.lua#L117. They're calling the API but also attempting to calculate the set bonus--this is incorrect on their end because once again Battlegear of Might changed to Immoveable Might. They're getting lucky though, since `GetBlockValue()` is already returning the correct block value including the set bonus, otherwise it would be overcounting.