### PR TITLE
Fix for issue - Addon breaks Looking For Group, stuck on searching #90

### DIFF
--- a/CharacterStatsClassicCore.lua
+++ b/CharacterStatsClassicCore.lua
@@ -27,6 +27,13 @@ characterStatsClassicEventFrame:SetScript("OnEvent",
             CSC_GenerateTalentsIndexMap();                
         end
 
+        -- Simple check: Don't update if LFG frames exist and are visible
+        if (LFGListingFrame and LFGListingFrame:IsVisible()) or 
+           (LFGListFrame and LFGListFrame:IsVisible()) or
+           InCombatLockdown() then
+            return;
+        end
+
         if (not core.UIConfig.CharacterStatsPanel:IsVisible()) then
             return;
         end
@@ -58,6 +65,14 @@ characterStatsClassicEventFrame:SetScript("OnEvent",
 
 function CSC_QueuedUpdate(self)
     self:SetScript("OnUpdate", nil);
+    
+    -- Double-check before updating
+    if (LFGListingFrame and LFGListingFrame:IsVisible()) or 
+       (LFGListFrame and LFGListFrame:IsVisible()) or
+       InCombatLockdown() then
+        return;
+    end
+    
     core.UIConfig:UpdateStats();
 end
 


### PR DESCRIPTION
## Problem
When queuing in LFG (Looking for Group), the addon throws an error:
[ADDON_ACTION_BLOCKED] AddOn 'CharacterStatsClassic' tried to call the protected function 'UNKNOWN()'.

## Solution
Added visibility checks for LFG frames before processing any UI updates. This prevents the addon from attempting to modify UI elements while the game is handling protected LFG operations.

## Changes Made
- Added `LFGListingFrame:IsVisible()` and `LFGListFrame:IsVisible()` checks in event handler
- Added same checks in `CSC_QueuedUpdate()` function as a safety measure
- Included `InCombatLockdown()` check for additional protection

## Testing
- Tested queuing for dungeons via LFG - no errors
- Verified character stats still update correctly when LFG is closed
- Confirmed no impact on normal addon functionality

Fixes #90 